### PR TITLE
size and pathlength violin plots - updated (May 19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/
 .Rproj.user
+.Rhistory

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -6,7 +6,7 @@ main <- function() {
   
   args <- commandArgs(TRUE)
   
-  ##using function to extract column names
+  ##using function to extract column names and change time column from factor to numeric
   parsed.data  <- extract.col(read.table("args[1]"))
   
   ## save data as a file
@@ -25,16 +25,6 @@ main <- function() {
   
   ## use mean size data to make width violin plot (with jittered points)
   violinplot.width(mean.size.data)
-  
-  ## use mean size data to make area box plot
-  boxplot.area(mean.size.data)
-  
-  ## use mean size data to make length box plot
-  boxplot.length(mean.size.data)
-  
-  ## use mean size data to make width box plot
-  boxplot.width(mean.size.data)
-  
   
 }
 
@@ -56,7 +46,7 @@ extract.col <- function(data){
   colnames(new.data) <- c("date", "plate", "time", "strain", "frame", "ID", "number", "goodnumber", "persistance", "area", "speed", "angularspeed", "length", "rellength", "width", "relwidth", "aspect", "relaspect", "midline", "morphwidth", "kink", "bias", "pathlen", "curve", "dir", "loc_x", "loc_y", "vel_x", "vel_y", "orient", "crab")
   
   ##replace time column (factor) with time as numeric
-  new.data$time  <- as.numeric(levels(parsed.data$time))[parsed.data$time]
+  new.data$time  <- as.numeric(levels(new.data$time))[new.data$time]
   
   return(new.data)
   
@@ -108,9 +98,6 @@ plot.speed.time <- function(parsed.data) {
 ## given parsed data make table with mean area, length, and width (from 60-70s) of each worm (including strain)
 mean.size <- function(parsed) {
   
-  ##replace time column (factor) with time as numeric
-  parsed.data$time  <- as.numeric(levels(parsed$time))[parsed$time]
-  
   ## subset parsed data to times between 60 seconds and 70 seconds
   time.subset <- parsed[parsed$time < 70 & parsed$time > 60, ]
   
@@ -120,94 +107,65 @@ mean.size <- function(parsed) {
 }
 
 ## given means, make body area violin plot
-## TODO: add axis labels with units, fix title
 violinplot.area <- function(mean.subset) {
   
-  ## initiate ggplot
-  g <- ggplot(mean.subset, aes(x = strain, y = area))
-  
-  ## make violin plot of area for each strain
-  g <- g+ggtitle("Violin Plot of Worm Area")          ## not sure if title is good or even needed..
-  g <- g+theme(plot.title = element_text(size=20, face="bold", vjust=2))
-  g <- g+geom_violin(alpha=0.5, color="gray") + geom_jitter(alpha = 0.5, position = position_jitter(width = 0.1))
+  g <- ggplot(mean.subset, aes(x = strain, y = area)) + ## plot lengths
+    theme(plot.title = element_text(size=20, face="bold", vjust=2), ## make the plot title larger and higher
+          panel.background = element_rect(fill = "white"), ## make the plot background grey
+          axis.text.x=element_text(colour="black", size = 12), ## change the x-axis values font to black
+          axis.text.y=element_text(colour="black", size = 12), ## change the y-axis values font to black and make larger
+          axis.title.x = element_text(size = 16, vjust = -0.2), ## change the x-axis label font to black, make larger, and move away from axis
+          axis.title.y = element_text(size = 16, vjust = 1.3)) + ## change the y-axis label font to black, make larger, and move away from axis
+    ggtitle("Violin Plot of Worm Area") +            ## set title
+    labs(x="Strain", y=expression(Area ~ (cm^{2}))) +     ## label the x and y axes 
+    geom_violin(alpha=0.5, color="gray", fill='#F0FFFF') +  ## overlay violin plot
+    geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) +  ## overlay jitter plot
+    geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
   g
 }
+
+violinplot.area(test.mean.data)
 
 ## given means, make body length violin plot
-## TODO: add axis labels with units, fix title
 violinplot.length <- function(mean.subset) {
   
-  ## initiate ggplot
-  g <- ggplot(mean.subset, aes(x = strain, y = length))
-  
-  ## make violin plot of length for each strain
-  g <- g+ggtitle("Violin Plot of Worm Length")
-  g <- g+theme(plot.title = element_text(size=20, face="bold", vjust=2))
-  g <- g+geom_violin(alpha=0.5, color="gray") + geom_jitter(alpha = 0.5, position = position_jitter(width = 0.1))
+  g <- ggplot(mean.subset, aes(x = strain, y = length)) + ## plot lengths
+    theme(plot.title = element_text(size=20, face="bold", vjust=2), ## make the plot title larger and higher
+          panel.background = element_rect(fill = "white"), ## make the plot background grey
+          axis.text.x=element_text(colour="black", size = 12), ## change the x-axis values font to black
+          axis.text.y=element_text(colour="black", size = 12), ## change the y-axis values font to black and make larger
+          axis.title.x = element_text(size = 16, vjust = -0.2), ## change the x-axis label font to black, make larger, and move away from axis
+          axis.title.y = element_text(size = 16, vjust = 1.3)) + ## change the y-axis label font to black, make larger, and move away from axis
+    ggtitle("Violin Plot of Worm Length") +            ## set title
+    labs(x="Strain", y="Length (mm)") +     ## label the x and y axes 
+    geom_violin(alpha=0.5, color="gray", fill='#F0FFFF') +  ## overlay violin plot
+    geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) +  ## overlay jitter plot
+    geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
   g
 }
+
 
 ## make body width violin plot
-## TODO: add axis labels with units, fix title
 violinplot.width <- function(mean.subset) {
   
-  ## initiate ggplot
-  g <- ggplot(mean.subset, aes(x = strain, y = width))
-  
-  ## make violin plot of length for each strain
-  g <- g+ggtitle("Violin Plot of Worm Width")
-  g <- g+theme(plot.title = element_text(size=20, face="bold", vjust=2))
-  g <- g+geom_violin(alpha=0.5, color="gray") + geom_jitter(alpha = 0.5, position = position_jitter(width = 0.1))
-  
-  g
-}
-
-## make area boxplot
-## TODO: add axis labels with units, fix title
-boxplot.area <- function(mean.subset) {
-  
-  #initiate ggplot
-  g <- ggplot(mean.subset, aes(x = strain, y = area))
-  
-  ## make boxplot
-  g <- g+ggtitle("Boxplot of Worm Area")
-  g <- g+geom_boxplot()  
+  ## make plot
+  g <- ggplot(mean.subset, aes(x = strain, y = width)) + ## plot widths
+    theme(plot.title = element_text(size=20, face="bold", vjust=2), ## make the plot title larger and higher
+          panel.background = element_rect(fill = "white"), ## make the plot background grey
+          axis.text.x=element_text(colour="black", size = 12), ## change the x-axis values font to black
+          axis.text.y=element_text(colour="black", size = 12), ## change the y-axis values font to black and make larger
+          axis.title.x = element_text(size = 16, vjust = -0.2), ## change the x-axis label font to black, make larger, and move away from axis
+          axis.title.y = element_text(size = 16, vjust = 1.3)) + ## change the y-axis label font to black, make larger, and move away from axis
+    ggtitle("Violin Plot of Worm Width") +            ## set title
+    labs(x="Strain", y="Width (mm)") +     ## label the x and y axes 
+    geom_violin(alpha=0.5, color="gray", fill='#F0FFFF') +  ## overlay violin plot
+    geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) + ## overlay jitter plot
+    geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
   g
 }
-
-## make length boxplot
-## TODO: add axis labels with units, fix title
-boxplot.length <- function(mean.subset) {
-  
-  #initiate ggplot
-  g <- ggplot(mean.subset, aes(x = strain, y = length))
-  
-  ## make boxplot
-  g <- g+ggtitle("Boxplot of Worm Length")
-  g <- g+geom_boxplot()  
-  
-  g
-}
-
-## make width boxplot
-## TODO: add axis labels with units, fix title
-boxplot.width <- function(mean.subset) {
-  
-  #initiate ggplot
-  g <- ggplot(mean.subset, aes(x = strain, y = width))
-  
-  ## make boxplot
-  g <- g+ggtitle("Boxplot of Worm Width")
-  g <- g+geom_boxplot()  
-  
-  g
-}
-
-
-
 
 
 ##save plot

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -119,6 +119,8 @@ mean.size <- function(parsed) {
   
   ## aggregate mean area, length, and width with each worm (ID), retaining strain and plate info
   mean.subset <- aggregate(cbind(area, length, width) ~ ID + strain + plate, time.subset, mean)  
+  
+  return(mean.subset)
 
 }
 
@@ -138,7 +140,7 @@ violinplot.area <- function(mean.size) {
     geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) +  ## overlay jitter plot
     geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
-  g
+  return(g)
 }
 
 ## given size means, make body length violin plot
@@ -157,7 +159,7 @@ violinplot.length <- function(mean.size) {
     geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) +  ## overlay jitter plot
     geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
-  g
+  return(g)
 }
 
 ## make body width violin plot
@@ -177,7 +179,7 @@ violinplot.width <- function(mean.size) {
     geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) + ## overlay jitter plot
     geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
-  g
+  return(g)
 }
 
 ## given parsed data return frame with mean pathlength (from 530 - 590s) for each worm, with ID, strain, and plate
@@ -253,7 +255,7 @@ violinplot.pathlength <- function(mean.pathlength) {
     geom_jitter(alpha = 0.5, position = position_jitter(width = 0.05), size = 3) +  ## overlay jitter plot
     geom_errorbar(stat = "hline", yintercept = "mean", width=0.4,aes(ymax=..y..,ymin=..y..)) ## overlay mean line
   
-  g
+  return(g)
 }
 
 

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -125,8 +125,6 @@ violinplot.area <- function(mean.subset) {
   g
 }
 
-violinplot.area(test.mean.data)
-
 ## given means, make body length violin plot
 violinplot.length <- function(mean.subset) {
   
@@ -145,7 +143,6 @@ violinplot.length <- function(mean.subset) {
   
   g
 }
-
 
 ## make body width violin plot
 violinplot.width <- function(mean.subset) {

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -182,12 +182,37 @@ violinplot.width <- function(mean.size) {
 
 ## given parsed data return frame with mean pathlength (from 530 - 590s) for each worm, with ID, strain, and plate
 mean.pathlength <- function(parsed) {
-    
+  
+#   ## nested function: given matrix or df of loc_x and loc_y, return total distance
+#   ## note: this implementation is noticeably slower
+#   pathlength <- function(xy) {
+#     out <- as.matrix(dist(xy))
+#     sum(out[row(out) - col(out) == 1])
+#   }
   
   ## nested function: given matrix or df of loc_x and loc_y, return total distance
+  ## quicker implementation
   pathlength <- function(xy) {
-    out <- as.matrix(dist(xy))
-    sum(out[row(out) - col(out) == 1])
+    
+    previous.x <- xy[1,1]      ## initiate previous x and y as first x and y values
+    previous.y <- xy[1,2]     
+    total <- 0                 ## initiate pathlength as 0
+    
+    for (i in 1:nrow(xy)) { ## use a for loop to go through each row of matrix (corresponding to an x,y point)
+      ## and calculate euclidean distance between each point and the previous point
+      
+      absdiff.x <- abs(xy[i,1] - previous.x)  ## get absolute difference current x position and previous x position
+      absdiff.y <- abs(xy[i,2] - previous.y)  
+      
+      total <- total + sqrt((absdiff.x)^2 + (absdiff.y)^2)  ## calculate diagonal of x and y difference (euclidean)
+      ## and add to total pathlength
+      
+      previous.x <- xy[i,1]  ## set current x as previous x
+      previous.y <- xy[i,2]  ## set current y as previous y
+      
+    }
+    
+    return(total)
   }
   
   ## subset parsed data to times between 530 and 590 seconds

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -17,14 +17,20 @@ main <- function() {
   ## use function to get mean size data for each worm (mean size data from 60 to 70s)
   mean.size.data <- mean.size(parsed.data)
   
-  ## use mean size data to make area violin plot (with jittered points)
+  ## make and save violin plot of worm area with jittered points (using mean size data)
+  pdf("Worm_Area_Plot.pdf")
   violinplot.area(mean.size.data)
+  dev.off()
   
-  ## use mean size data to make length violin plot (with jittered points)
+  ## make and save violin plot of worm length with jittered points (using mean size data)
+  pdf("Worm_Length_Plot.pdf")
   violinplot.length(mean.size.data)
+  dev.off()
   
-  ## use mean size data to make width violin plot (with jittered points)
+  ## make and save violin plot of worm width with jittered points (using mean size data)
+  pdf("Worm_Width_Plot.pdf")
   violinplot.width(mean.size.data)
+  dev.off()
   
 }
 

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -203,10 +203,10 @@ mean.pathlength <- function(parsed) {
     for (i in 1:nrow(xy)) { ## use a for loop to go through each row of matrix (corresponding to an x,y point)
       ## and calculate euclidean distance between each point and the previous point
       
-      absdiff.x <- abs(xy[i,1] - previous.x)  ## get absolute difference current x position and previous x position
-      absdiff.y <- abs(xy[i,2] - previous.y)  
+      diff.x <- xy[i,1] - previous.x  ## get difference between current x position and previous x position
+      diff.y <- xy[i,2] - previous.y
       
-      total <- total + sqrt((absdiff.x)^2 + (absdiff.y)^2)  ## calculate diagonal of x and y difference (euclidean)
+      total <- total + sqrt((diff.x)^2 + (diff.y)^2)  ## calculate diagonal of x and y difference (euclidean)
       ## and add to total pathlength
       
       previous.x <- xy[i,1]  ## set current x as previous x

--- a/bin/Column_identification.R
+++ b/bin/Column_identification.R
@@ -12,7 +12,30 @@ main <- function() {
   ## save data as a file
   write.table(parsed.data, file="args[1].parsed", col.names=TRUE, row.names=FALSE, quote=FALSE, append=FALSE)
   
-  ##call script to call speed vs. time
+  ## call script to call speed vs. time
+
+  ## use function to get mean size data for each worm (mean size data from 60 to 70s)
+  mean.size.data <- mean.size(parsed.data)
+  
+  ## use mean size data to make area violin plot (with jittered points)
+  violinplot.area(mean.size.data)
+  
+  ## use mean size data to make length violin plot (with jittered points)
+  violinplot.length(mean.size.data)
+  
+  ## use mean size data to make width violin plot (with jittered points)
+  violinplot.width(mean.size.data)
+  
+  ## use mean size data to make area box plot
+  boxplot.area(mean.size.data)
+  
+  ## use mean size data to make length box plot
+  boxplot.length(mean.size.data)
+  
+  ## use mean size data to make width box plot
+  boxplot.width(mean.size.data)
+  
+  
 }
 
 
@@ -27,11 +50,13 @@ extract.col <- function(data){
   strain <- str_extract(data$V1,"[A-Za-z]+[-]?[0-9]+")
   
   ## combine new columns with merged file
-  new.data <- cbind(date, plate, time, strain, data[,2:dim(data)[2]])
-  
+  new.data <- cbind(date, plate, time, strain, data[,2:dim(data)[2]])  
   
   ##rename columns  
   colnames(new.data) <- c("date", "plate", "time", "strain", "frame", "ID", "number", "goodnumber", "persistance", "area", "speed", "angularspeed", "length", "rellength", "width", "relwidth", "aspect", "relaspect", "midline", "morphwidth", "kink", "bias", "pathlen", "curve", "dir", "loc_x", "loc_y", "vel_x", "vel_y", "orient", "crab")
+  
+  ##replace time column (factor) with time as numeric
+  new.data$time  <- as.numeric(levels(parsed.data$time))[parsed.data$time]
   
   return(new.data)
   
@@ -40,9 +65,6 @@ extract.col <- function(data){
 ##function for plotting time vs. speed
 
 plot.speed.time <- function(parsed.data) {
-
-  ##replace time column (factor) with time as numeric
-  parsed.data$time  <- as.numeric(levels(parsed.data$time))[parsed.data$time]
   
   ##plot speed decay over time  
   ##bin into time intervals to make it quicker to plot (average speed over every 20s for 10 min)
@@ -83,7 +105,106 @@ plot.speed.time <- function(parsed.data) {
   
 }
 
+## given parsed data make table with mean area, length, and width (from 60-70s) of each worm (including strain)
+mean.size <- function(parsed) {
+  
+  ##replace time column (factor) with time as numeric
+  parsed.data$time  <- as.numeric(levels(parsed$time))[parsed$time]
+  
+  ## subset parsed data to times between 60 seconds and 70 seconds
+  time.subset <- parsed[parsed$time < 70 & parsed$time > 60, ]
+  
+  ## aggregate mean area, length, and width of each worm with each strain
+  mean.subset <- aggregate(cbind(area, length, width) ~ ID + strain, time.subset, mean)
 
+}
+
+## given means, make body area violin plot
+## TODO: add axis labels with units, fix title
+violinplot.area <- function(mean.subset) {
+  
+  ## initiate ggplot
+  g <- ggplot(mean.subset, aes(x = strain, y = area))
+  
+  ## make violin plot of area for each strain
+  g <- g+ggtitle("Violin Plot of Worm Area")          ## not sure if title is good or even needed..
+  g <- g+theme(plot.title = element_text(size=20, face="bold", vjust=2))
+  g <- g+geom_violin(alpha=0.5, color="gray") + geom_jitter(alpha = 0.5, position = position_jitter(width = 0.1))
+  
+  g
+}
+
+## given means, make body length violin plot
+## TODO: add axis labels with units, fix title
+violinplot.length <- function(mean.subset) {
+  
+  ## initiate ggplot
+  g <- ggplot(mean.subset, aes(x = strain, y = length))
+  
+  ## make violin plot of length for each strain
+  g <- g+ggtitle("Violin Plot of Worm Length")
+  g <- g+theme(plot.title = element_text(size=20, face="bold", vjust=2))
+  g <- g+geom_violin(alpha=0.5, color="gray") + geom_jitter(alpha = 0.5, position = position_jitter(width = 0.1))
+  
+  g
+}
+
+## make body width violin plot
+## TODO: add axis labels with units, fix title
+violinplot.width <- function(mean.subset) {
+  
+  ## initiate ggplot
+  g <- ggplot(mean.subset, aes(x = strain, y = width))
+  
+  ## make violin plot of length for each strain
+  g <- g+ggtitle("Violin Plot of Worm Width")
+  g <- g+theme(plot.title = element_text(size=20, face="bold", vjust=2))
+  g <- g+geom_violin(alpha=0.5, color="gray") + geom_jitter(alpha = 0.5, position = position_jitter(width = 0.1))
+  
+  g
+}
+
+## make area boxplot
+## TODO: add axis labels with units, fix title
+boxplot.area <- function(mean.subset) {
+  
+  #initiate ggplot
+  g <- ggplot(mean.subset, aes(x = strain, y = area))
+  
+  ## make boxplot
+  g <- g+ggtitle("Boxplot of Worm Area")
+  g <- g+geom_boxplot()  
+  
+  g
+}
+
+## make length boxplot
+## TODO: add axis labels with units, fix title
+boxplot.length <- function(mean.subset) {
+  
+  #initiate ggplot
+  g <- ggplot(mean.subset, aes(x = strain, y = length))
+  
+  ## make boxplot
+  g <- g+ggtitle("Boxplot of Worm Length")
+  g <- g+geom_boxplot()  
+  
+  g
+}
+
+## make width boxplot
+## TODO: add axis labels with units, fix title
+boxplot.width <- function(mean.subset) {
+  
+  #initiate ggplot
+  g <- ggplot(mean.subset, aes(x = strain, y = width))
+  
+  ## make boxplot
+  g <- g+ggtitle("Boxplot of Worm Width")
+  g <- g+geom_boxplot()  
+  
+  g
+}
 
 
 


### PR DESCRIPTION
I added to the end of extract.col so that it also changes the time factor to numeric - that way we don't have to call it in every function (don't think we ever need it as a factor).

I'm happy with the violin plots for area, length and width.

For the pathlength violin plot, my function for finding the pathlength works well, but I'm not too happy with my implementation for aggregating the data by pathlength.

Right now, I'm aggregating the data with an arbitrary function (max), and then replacing the arbitrary values with actual pathlengths (found by pathlength function). It works, but it relies on the "by" and "aggregate" functions to group in identical order - which they seem to do right now (once I drop the NA values from by).

Maybe you can suggest a better way to aggregate the data with the new pathlengths - I had trouble using ddply from plyr.
